### PR TITLE
Enhancement to allow additional focused spec types other than fdescribe and fit

### DIFF
--- a/spec/src/no_focused_jasmine_specs_spec.coffee
+++ b/spec/src/no_focused_jasmine_specs_spec.coffee
@@ -56,3 +56,25 @@ describe 'test', ->
       expect(error.level).toBe 'warn'
       expect(error.lineNumber).toBe 2
       expect(error.rule).toBe 'no_focused_jasmine_specs'
+
+  describe 'a focused anything spec', ->
+
+    beforeEach ->
+      config =
+        no_focused_jasmine_specs:
+          level: 'warn'
+          additional: ['ffoo']
+
+      ffooSpec = '''
+        describe "A suite", ->
+          ffoo "contains a focus spec", ->
+            expect(true).toBe false
+      '''
+      @errors = coffeelint.lint(ffooSpec, config)
+
+    it 'has an error on line 1', ->
+      expect(@errors.length).toBe 1
+      error = @errors[0]
+      expect(error.level).toBe 'warn'
+      expect(error.lineNumber).toBe 2
+      expect(error.rule).toBe 'no_focused_jasmine_specs'

--- a/src/no_focused_jasmine_specs.coffee
+++ b/src/no_focused_jasmine_specs.coffee
@@ -9,11 +9,12 @@ class NoFocusedJasmineSpecs
       This rule will call linting to fail if a focused (fdescribe/fit) spec is
       encountered.
     '''
+    overrides: []
 
   tokens: ['IDENTIFIER']
 
   lintToken: (token, tokenApi) ->
-    if token[1] in FOCUSED_SPECS
+    if token[1] in FOCUSED_SPECS.concat(overrides)
       true
 
 module.exports = NoFocusedJasmineSpecs

--- a/src/no_focused_jasmine_specs.coffee
+++ b/src/no_focused_jasmine_specs.coffee
@@ -9,12 +9,13 @@ class NoFocusedJasmineSpecs
       This rule will call linting to fail if a focused (fdescribe/fit) spec is
       encountered.
     '''
-    overrides: []
+    additional: []
 
   tokens: ['IDENTIFIER']
 
   lintToken: (token, tokenApi) ->
-    if token[1] in FOCUSED_SPECS.concat(overrides)
+    {additional} = tokenApi.config[@rule.name]
+    if token[1] in FOCUSED_SPECS.concat(additional)
       true
 
 module.exports = NoFocusedJasmineSpecs


### PR DESCRIPTION
Hi there!

First, thanks for creating this coffeelint rule. My team is going to start using it very soon. However, we also have custom functions for our specs that we've written that behave the same way as `fdescribe` and `fit`. For instance, we have aliased `describe` as `context` along with `fcontext`. Since this rule only picks up the two base spec keywords, I decided to open a PR that allows other spec keywords to be caught as well.

Thanks for your time!